### PR TITLE
Treat GOST like SIGALGS for cert verify

### DIFF
--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -537,7 +537,7 @@ int ssl3_digest_cached_records(SSL *s, int keep)
         }
 
         /* Loop through bits of algorithm2 field and create MD_CTX-es */
-        for (i = 0; ssl_get_certverify_digest(i, &mask, &md); i++) {
+        for (i = 0; ssl_get_handshake_digest(i, &mask, &md); i++) {
             if ((mask & ssl_get_algorithm2(s)) && md) {
                 s->s3->handshake_dgst[i] = EVP_MD_CTX_create();
                 if (EVP_MD_nid(md) == NID_md5) {

--- a/ssl/s3_srvr.c
+++ b/ssl/s3_srvr.c
@@ -578,7 +578,9 @@ int ssl3_accept(SSL *s)
                  */
                 s->state = SSL3_ST_SR_CHANGE_A;
                 s->init_num = 0;
-            } else if (SSL_USE_SIGALGS(s)) {
+            } else if (SSL_USE_SIGALGS(s)
+                    || (s->s3->tmp.new_cipher->algorithm_auth
+                        & (SSL_aGOST12|SSL_aGOST01) )) {
                 s->state = SSL3_ST_SR_CERT_VRFY_A;
                 s->init_num = 0;
                 if (!s->session->peer)
@@ -1426,7 +1428,9 @@ int ssl3_get_client_hello(SSL *s)
         s->s3->tmp.new_cipher = s->session->cipher;
     }
 
-    if (!SSL_USE_SIGALGS(s) || !(s->verify_mode & SSL_VERIFY_PEER)) {
+    if (!(SSL_USE_SIGALGS(s) || (s->s3->tmp.new_cipher->algorithm_auth
+                                 & (SSL_aGOST12|SSL_aGOST01)))
+            || !(s->verify_mode & SSL_VERIFY_PEER)) {
         if (!ssl3_digest_cached_records(s, 0))
             goto f_err;
     }
@@ -2868,7 +2872,10 @@ int ssl3_get_cert_verify(SSL *s)
         goto f_err;
     }
 
-    if (SSL_USE_SIGALGS(s)) {
+    if (SSL_USE_SIGALGS(s)
+            || pkey->type == NID_id_GostR3410_2001
+            || pkey->type == NID_id_GostR3410_2012_256
+            || pkey->type == NID_id_GostR3410_2012_512) {
         long hdatalen = 0;
         void *hdata;
         hdatalen = BIO_get_mem_data(s->s3->handshake_buffer, &hdata);
@@ -2881,6 +2888,15 @@ int ssl3_get_cert_verify(SSL *s)
         fprintf(stderr, "Using TLS 1.2 with client verify alg %s\n",
                 EVP_MD_name(md));
 #endif
+        if (!SSL_USE_SIGALGS(s)) {
+            int dgst_nid;
+            if (EVP_PKEY_get_default_digest_nid(pkey, &dgst_nid) <= 0
+                || (md = EVP_get_digestbynid(dgst_nid)) == NULL) {
+                SSLerr(SSL_F_SSL3_GET_CERT_VERIFY, ERR_R_INTERNAL_ERROR);
+                al = SSL_AD_INTERNAL_ERROR;
+                goto f_err;
+            }
+        }
         if (!EVP_VerifyInit_ex(&mctx, md, NULL)
             || !EVP_VerifyUpdate(&mctx, hdata, hdatalen)) {
             SSLerr(SSL_F_SSL3_GET_CERT_VERIFY, ERR_R_EVP_LIB);
@@ -2948,41 +2964,7 @@ int ssl3_get_cert_verify(SSL *s)
         }
     } else
 #endif
-    if (pkey->type == NID_id_GostR3410_2001 
-            || pkey->type == NID_id_GostR3410_2012_256
-            || pkey->type == NID_id_GostR3410_2012_512) {
-        unsigned char signature[128];
-        size_t sigsize = (pkey->type == NID_id_GostR3410_2012_512) ? 128 : 64;
-        size_t dgstsize = (pkey->type == NID_id_GostR3410_2012_512) ? 64 : 32;
-
-        /*
-         * We can have
-         *    - client cert 34.10-94/2001 with 32-bytes digest offset 0
-         *    - client cert 34.10-2012 256 with 32-bytes digest offset 32
-         *    - client cert 34.10-2012 512 with 64-bytes digest offset 64
-         */
-        size_t offset = (pkey->type == NID_id_GostR3410_2012_512) ? 64
-            : ((pkey->type == NID_id_GostR3410_2012_256) ? 32 : 0);
-        size_t idx;
-        EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new(pkey, NULL);
-        EVP_PKEY_verify_init(pctx);
-        if (len != sigsize) {
-            al = SSL_AD_DECODE_ERROR;
-            SSLerr(SSL_F_SSL3_GET_CERT_VERIFY, SSL_R_BAD_GOST_SIGNATURE);
-            goto f_err;
-        }
-        for (idx = 0; idx < sigsize; idx++) {
-            signature[sigsize - 1 - idx] = data[idx];
-        }
-        j = EVP_PKEY_verify(pctx, signature, sigsize,
-                            s->s3->tmp.cert_verify_md + offset, dgstsize);
-        EVP_PKEY_CTX_free(pctx);
-        if (j <= 0) {
-            al = SSL_AD_DECRYPT_ERROR;
-            SSLerr(SSL_F_SSL3_GET_CERT_VERIFY, SSL_R_BAD_GOST_SIGNATURE);
-            goto f_err;
-        }
-    } else {
+    {
         SSLerr(SSL_F_SSL3_GET_CERT_VERIFY, ERR_R_INTERNAL_ERROR);
         al = SSL_AD_UNSUPPORTED_CERTIFICATE;
         goto f_err;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -285,13 +285,6 @@ static const int ssl_handshake_digest_flag[SSL_MD_NUM_IDX] = {
     SSL_HANDSHAKE_MAC_GOST12_512,
 };
 
-static int ssl_certverify_digest_flag[SSL_MD_NUM_IDX] = {
-    SSL_HANDSHAKE_MAC_MD5, SSL_HANDSHAKE_MAC_SHA,
-    SSL_HANDSHAKE_MAC_GOST, 0, SSL_HANDSHAKE_MAC_SHA256,
-    SSL_HANDSHAKE_MAC_SHA384, SSL_HANDSHAKE_MAC_GOST, 0,
-    SSL_HANDSHAKE_MAC_GOST,
-};
-
 #define CIPHER_ADD      1
 #define CIPHER_KILL     2
 #define CIPHER_DEL      3
@@ -736,19 +729,6 @@ int ssl_get_handshake_digest(int idx, long *mask, const EVP_MD **md)
         return 0;
     }
     *mask = ssl_handshake_digest_flag[idx];
-    if (*mask)
-        *md = ssl_digest_methods[idx];
-    else
-        *md = NULL;
-    return 1;
-}
-
-int ssl_get_certverify_digest(int idx, long *mask, const EVP_MD **md)
-{
-    if (idx < 0 || idx >= SSL_MD_NUM_IDX) {
-        return 0;
-    }
-    *mask = ssl_certverify_digest_flag[idx];
     if (*mask)
         *md = ssl_digest_methods[idx];
     else

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -1894,7 +1894,6 @@ __owur int ssl_cipher_get_evp(const SSL_SESSION *s, const EVP_CIPHER **enc,
                        const EVP_MD **md, int *mac_pkey_type,
                        int *mac_secret_size, SSL_COMP **comp, int use_etm);
 __owur int ssl_get_handshake_digest(int i, long *mask, const EVP_MD **md);
-__owur int ssl_get_certverify_digest(int i, long *mask, const EVP_MD **md);
 __owur int ssl_cipher_get_cert_index(const SSL_CIPHER *c);
 __owur const SSL_CIPHER *ssl_get_cipher_by_char(SSL *ssl, const unsigned char *ptr);
 __owur int ssl_cert_set0_chain(SSL *s, SSL_CTX *ctx, STACK_OF(X509) *chain);


### PR DESCRIPTION
GOST can use a number of different digests for the handshake data in
processing a CertificateVerify. Therefore we should keep the handshake data
around until we have processed the CertificateVerify message so that we
can calculate the correct digest. This is much the same way that the
SIGALGS code works now.
